### PR TITLE
Make the groups that we request flexible.

### DIFF
--- a/pyramid_fas_openid/view.py
+++ b/pyramid_fas_openid/view.py
@@ -108,7 +108,11 @@ def process_incoming_request(context, request, incoming_openid_url):
                     optional=sreg_optional)
             openid_request.addExtension(sreq)
 
-        openid_request.addExtension(teams.TeamsRequest(requested=['_FAS_ALL_GROUPS_'])) # Magic value which requests all groups from FAS-OpenID >= 0.2.0
+        # Default is magic which requests all groups from FAS-OpenID >= 0.2.0
+        groups = request.registry.settings.get('openid.groups', '_FAS_ALL_GROUPS_')
+        if isinstance(groups, basestring):
+            groups = [group.strip() for group in groups.split()]
+        openid_request.addExtension(teams.TeamsRequest(requested=groups))
         openid_request.addExtension(cla.CLARequest(requested=[cla.CLA_URI_FEDORA_DONE]))
     except consumer.DiscoveryFailure, exc:
         # eventually no openid server could be found

--- a/pyramid_fas_openid/view.py
+++ b/pyramid_fas_openid/view.py
@@ -111,7 +111,7 @@ def process_incoming_request(context, request, incoming_openid_url):
         # Default is magic which requests all groups from FAS-OpenID >= 0.2.0
         groups = request.registry.settings.get('openid.groups', '_FAS_ALL_GROUPS_')
         if isinstance(groups, basestring):
-            groups = [group.strip() for group in groups.split()]
+            groups = groups.split()
         openid_request.addExtension(teams.TeamsRequest(requested=groups))
         openid_request.addExtension(cla.CLARequest(requested=[cla.CLA_URI_FEDORA_DONE]))
     except consumer.DiscoveryFailure, exc:


### PR DESCRIPTION
I'm pretty sure we need to do this.  I have a vague memory of some bug where
some users have an insane number of groups and it causes fedoauth to barf (or
render weirdly or something).

This is for bodhi2.