### PR TITLE
Python3 compatibility changes

### DIFF
--- a/pyramid_fas_openid/__init__.py
+++ b/pyramid_fas_openid/__init__.py
@@ -1,1 +1,2 @@
-from view import verify_openid
+from __future__ import absolute_import
+from .view import verify_openid

--- a/pyramid_fas_openid/view.py
+++ b/pyramid_fas_openid/view.py
@@ -12,19 +12,11 @@ TODO:
             request with openid field that comes back successful
                     and calls callback
 """
-import urlparse
-
-import openid
-from openid.store import memstore, filestore, sqlstore
 from openid.consumer import consumer
-from openid.oidutil import appendArgs
-from openid.cryptutil import randomString
-from openid.fetchers import setDefaultFetcher, Urllib2Fetcher
-from openid.extensions import pape, sreg, ax
+from openid.extensions import sreg, ax
 
 from pyramid.httpexceptions import HTTPFound
 from pyramid.httpexceptions import HTTPBadRequest
-from pyramid.security import remember
 
 from openid_teams import teams
 from openid_cla import cla

--- a/pyramid_fas_openid/view.py
+++ b/pyramid_fas_openid/view.py
@@ -107,10 +107,10 @@ def process_incoming_request(context, request, incoming_openid_url):
             groups = groups.split()
         openid_request.addExtension(teams.TeamsRequest(requested=groups))
         openid_request.addExtension(cla.CLARequest(requested=[cla.CLA_URI_FEDORA_DONE]))
-    except consumer.DiscoveryFailure, exc:
+    except consumer.DiscoveryFailure as exc:
         # eventually no openid server could be found
         return error_to_login_form(request, 'Error in discovery: %s' % exc[0])
-    except KeyError, exc:
+    except KeyError as exc:
         # TODO: when does that happen, why does plone.openid use "pass" here?
         return error_to_login_form(request, 'Error in discovery: %s' % exc[0])
     # not sure this can still happen but we are making sure.

--- a/pyramid_fas_openid/view.py
+++ b/pyramid_fas_openid/view.py
@@ -70,7 +70,7 @@ def verify_openid(context, request):
     return HTTPBadRequest()
 
 
-def worthless_callback(request, success_args, success_dict = {}):
+def worthless_callback(request, success_args, success_dict=None):
     pass
 
 

--- a/pyramid_fas_openid/view.py
+++ b/pyramid_fas_openid/view.py
@@ -24,6 +24,7 @@ from openid_cla import cla
 from itertools import chain
 
 import logging
+import six
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +103,7 @@ def process_incoming_request(context, request, incoming_openid_url):
 
         # Default is magic which requests all groups from FAS-OpenID >= 0.2.0
         groups = request.registry.settings.get('openid.groups', '_FAS_ALL_GROUPS_')
-        if isinstance(groups, basestring):
+        if isinstance(groups, six.string_types):
             groups = groups.split()
         openid_request.addExtension(teams.TeamsRequest(requested=groups))
         openid_request.addExtension(cla.CLARequest(requested=[cla.CLA_URI_FEDORA_DONE]))

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,17 @@
 import os
+import sys
 from setuptools import setup, find_packages
 version = '0.3.8'
 README = os.path.join(os.path.dirname(__file__), 'README.txt')
 long_description = open(README).read()
+
+install_requires = ['pyramid', 'python-openid-teams',
+                    'python-openid-cla', 'six']
+if sys.version_info.major == 3:
+    install_requires.append('python3-openid')
+else:
+    install_requires.append('python-openid')
+
 
 setup(name='pyramid_fas_openid',
         version=version,
@@ -23,6 +32,5 @@ setup(name='pyramid_fas_openid',
         author_email='lmacken@redhat.com',
         license='BSD-derived (http://www.repoze.org/LICENSE.txt)',
         packages=find_packages(),
-        install_requires=['pyramid', 'python-openid', 'python-openid-teams',
-                          'python-openid-cla']
+        install_requires=install_requires
 )


### PR DESCRIPTION
Hello.

Pyramid-fas-openid is one of the Bodhis dependencies and we have to make it Python 3 compatible before we start with making Bodhi Python 3 compatible so I've prepared PR with some changes.

Unfortunately, I don't know the way how can I test this module. But at least I tried installation, import etc.

If you approve this PR, could you also please make a new release so I can prepare new specfile with python2/python3 subpackages?

Thanks a lot!