### PR TITLE
Add support for the new AAA system.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.4.0
+-----
+
+- Support for the new AAA system, which adds users who have signed agreement
+  "foobar" to the ``signed_foobar`` group. Make use of this to set the
+  ``cla_done`` key.
+
+
 0.3.9
 -----
 

--- a/pyramid_fas_openid/view.py
+++ b/pyramid_fas_openid/view.py
@@ -166,6 +166,10 @@ def process_provider_response(context, request):
 
         cla_resp = cla.CLAResponse.fromSuccessResponse(info)
         success_dict['cla_done'] = cla.CLA_URI_FEDORA_DONE in cla_resp.clas
+        # In the new AAA system, signing an agreement adds the user to a
+        # specific group. The FPCA has replaced the CLA.
+        if "signed_fpca" in success_dict['groups']:
+            success_dict['cla_done'] = True
 
         callback = settings.get('openid.success_callback', None)
         if callback is not None:


### PR DESCRIPTION
The new AAA system adds users who have signed agreement "foobar" to the `signed_foobar` group. Make use of this to set the `cla_done` key.

This relates to fedora-infra/aaa-tracker#8.